### PR TITLE
Message without payload should not raise error

### DIFF
--- a/lib/creditsafe/client.rb
+++ b/lib/creditsafe/client.rb
@@ -161,19 +161,10 @@ module Creditsafe
                fetch(:list_monitored_companies_result)
 
       messages = result[:messages].nil? ? [] : result.fetch(:messages).fetch(:message)
-      result = result.fetch(:portfolios)
-      result = result.is_a?(Array) ? result : [result]
+      result = result.fetch(:portfolios, [])
+      result = [result].flatten
 
       { result: result, messages: messages }
-    rescue
-      if messages == 'There are no results matching specified criteria.'
-        return { result: [], messages: [] }
-      end
-
-      if messages.is_a?(Array)
-        messages = messages.reduce { |a, e| a + ' ; ' + e }
-      end
-      raise '' + messages
     end
 
     # rubocop:disable AccessorMethodName

--- a/lib/creditsafe/client.rb
+++ b/lib/creditsafe/client.rb
@@ -161,6 +161,7 @@ module Creditsafe
                fetch(:list_monitored_companies_result)
 
       messages = result[:messages].nil? ? [] : result.fetch(:messages).fetch(:message)
+      messages = [messages].flatten
       result = result.fetch(:portfolios, [])
       result = [result].flatten
 

--- a/spec/creditsafe/client_spec.rb
+++ b/spec/creditsafe/client_spec.rb
@@ -732,8 +732,15 @@ RSpec.describe(Creditsafe::Client) do
           to_return(body: load_fixture('list-monitored-companies-multiple-messages.xml'))
       end
 
-      it 'should raise an error' do
-        expect { list_monitored_companies }.to raise_error
+      it 'should not raise an error' do
+        expect { list_monitored_companies }.not_to raise_error
+      end
+
+      it 'should return empty message' do
+        expect(list_monitored_companies).to eq(
+          messages: ['There are no results matching specified criteria.', 'bla'],
+          result: []
+        )
       end
     end
 


### PR DESCRIPTION
`list_monitored_companies` should return an empty array if there are no results.

Nb. the exact result is 'There are no results matching specified criteria' 